### PR TITLE
Trigger the libtool rules if gtk-doc uses it

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -235,7 +235,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 		if test "x$(am__dirstamp)" = x; then :; else \
 			echo "$(am__dirstamp)"; \
 		fi; \
-		if test "x$(LTCOMPILE)" = x; then :; else \
+		if test "x$(LTCOMPILE)" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
 			for x in \
 				"*.lo" \
 				".libs" "_libs" \


### PR DESCRIPTION
gtk-doc may use libtool to build and run the `gtkdoc-scangobj` helper
programs but does so without defining the LTCOMPILE variable, causing
the libtool detection logic to fail and .libs directories do not get
added to the ignore list.

Since there's no explicit variable telling us if GTK_DOC_USE_LIBTOOL was
set, rely on GTKDOC_RUN being unset when libtool is not used.

The issue can be tested on the GTK+ repository making sure that the
`--enable-gtk-doc` configure flag has been set.
