### PR TITLE
Ignore test-driver

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -89,6 +89,7 @@ GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL = \
 		ltmain.sh \
 		missing \
 		mkinstalldirs \
+		test-driver \
 	 ; do echo "$$AUX_DIR/$$x"; done` \
 	`cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_HEADERS:$$1' ./configure.ac | \
 	head -n 1 | while read f; do echo "$(srcdir)/$$f.in"; done`


### PR DESCRIPTION
The parallel tests harness from Automake, enabled by default [since automake 1.12b](http://git.savannah.gnu.org/cgit/automake.git/commit/?id=5e771b2) and in previous versions by the `parallel-tests` option in `AM_INIT_AUTOMAKE`, uses the above script to log the tests output if no other driver is specified with the [`($prefix_)LOG_DRIVER` variables](http://git.savannah.gnu.org/cgit/automake.git/tree/bin/automake.in#n4580).
