### PR TITLE
Support Vala-generated C header files in subdirectories

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -273,7 +273,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			$(patsubst %.vala,%.c,$(filter %.vala,$(SOURCES))) \
 			$(filter %_vala.stamp,$(DIST_COMMON)) \
 			$(filter %.vapi,$(DIST_COMMON)) \
-			$(patsubst %.vapi,%.h,$(filter %.vapi,$(DIST_COMMON))) \
+			$(filter %$(patsubst %.vapi,%.h,$(filter %.vapi,$(DIST_COMMON))),$(DIST_COMMON)) \
 			Makefile \
 			Makefile.in \
 			"*.orig" \


### PR DESCRIPTION
valac can generate C header files using its --header option. If the
--includedir option is also specified, the header file will be generated
in the given (sub)directory. git.mk previously assumed all generated
header files were in the current directory. This change fixes that so it
gets the full header file path from $(DIST_COMMON).
