### PR TITLE
Support AppData validation files

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -45,7 +45,7 @@
 # build dir.
 #
 # This file knows how to handle autoconf, automake, libtool, gtk-doc,
-# gnome-doc-utils, yelp.m4, mallard, intltool, gsettings, dejagnu.
+# gnome-doc-utils, yelp.m4, mallard, intltool, gsettings, dejagnu, appdata.
 #
 # This makefile provides the following targets:
 #
@@ -200,6 +200,11 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			for x in \
 				$(gsettings_SCHEMAS:.xml=.valid) \
 				$(gsettings__enum_file) \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(appdata_XML)" = x; then :; else \
+			for x in \
+				$(appdata_XML:.xml=.valid) \
 			; do echo "/$$x"; done; \
 		fi; \
 		if test -f $(srcdir)/po/Makefile.in.in; then \


### PR DESCRIPTION
If using the standard appdata-xml.m4 macros for building and validating
AppData files, a .valid file will be generated for each .appdata.xml
file. Add support for this in git.mk.
