### PR TITLE
Fix support for Vala-generated C header files in subdirectories

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -278,7 +278,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			$(patsubst %.vala,%.c,$(filter %.vala,$(SOURCES))) \
 			$(filter %_vala.stamp,$(DIST_COMMON)) \
 			$(filter %.vapi,$(DIST_COMMON)) \
-			$(filter %$(patsubst %.vapi,%.h,$(filter %.vapi,$(DIST_COMMON))),$(DIST_COMMON)) \
+			$(filter $(addprefix %,$(notdir $(patsubst %.vapi,%.h,$(filter %.vapi,$(DIST_COMMON))))),$(DIST_COMMON)) \
 			Makefile \
 			Makefile.in \
 			"*.orig" \


### PR DESCRIPTION
The support for Vala-generated C header files which was added in commit
60215e7967743ee35bff99f2a8d9f9b3a47c9e11 has two problems:
 • If a project does not use VAPI files, the whole of $(DIST_COMMON)
   gets included in .gitignore, which is completely incorrect.
 • If $(srcdir) is used as a prefix for the VAPI files and C header
   files, extraction of the header file paths from $(DIST_COMMON) fails.

Fix that by not doing a wildcard filter which depends on a potentially
empty string.

Fixes #16.
