### PR TITLE
Support files generated by gcov

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -267,6 +267,8 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			$(TEST_LOGS:.log=.trs) \
 			$(TEST_SUITE_LOG) \
 			"*.$(OBJEXT)" \
+			"*.gcda" \
+			"*.gcno" \
 			$(DISTCLEANFILES) \
 			$(am__CONFIG_DISTCLEAN_FILES) \
 			$(CONFIG_CLEAN_FILES) \


### PR DESCRIPTION
gcov generates files with the same name as the object files, but with
the extension replaced by *.gcda and *.gcno.   For more information,
see http://gcc.gnu.org/onlinedocs/gcc/Gcov-Data-Files.html
