### PR TITLE
Support appstream files in addition to appdata

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -45,7 +45,8 @@
 # build dir.
 #
 # This file knows how to handle autoconf, automake, libtool, gtk-doc,
-# gnome-doc-utils, yelp.m4, mallard, intltool, gsettings, dejagnu, appdata.
+# gnome-doc-utils, yelp.m4, mallard, intltool, gsettings, dejagnu, appdata,
+# appstream.
 #
 # This makefile provides the following targets:
 #
@@ -205,6 +206,11 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 		if test "x$(appdata_XML)" = x; then :; else \
 			for x in \
 				$(appdata_XML:.xml=.valid) \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(appstream_XML)" = x; then :; else \
+			for x in \
+				$(appstream_XML:.xml=.valid) \
 			; do echo "/$$x"; done; \
 		fi; \
 		if test -f $(srcdir)/po/Makefile.in.in; then \


### PR DESCRIPTION
appdata-tools is dead, and applications should port to appstream-glib,
which subtly changes its macros.
