### PR TITLE
Fix ignored libtool directories in C++ projects

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -248,7 +248,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 		if test "x$(am__dirstamp)" = x; then :; else \
 			echo "$(am__dirstamp)"; \
 		fi; \
-		if test "x$(LTCOMPILE)" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
+		if test "x$(LTCOMPILE)" = x -a "x$(LTCXXCOMPILE)" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
 			for x in \
 				"*.lo" \
 				".libs" "_libs" \


### PR DESCRIPTION
In C++ projects, $(LTCXXCOMPILE) is defined but not $(LTCOMPILE).

Fixes Issue #23
