### PR TITLE
Ignore ylwrap

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -90,6 +90,7 @@ GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL = \
 		missing \
 		mkinstalldirs \
 		test-driver \
+		ylwrap \
 	 ; do echo "$$AUX_DIR/$$x"; done` \
 	`cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_HEADERS:$$1' ./configure.ac | \
 	head -n 1 | while read f; do echo "$(srcdir)/$$f.in"; done`


### PR DESCRIPTION
ylwrap gets generated in AC_CONFIG_AUX_DIR if the project is using Autotools' support for yacc and lex. It'd be nice if this was ignored by default.
