### PR TITLE
Add support for installed-tests metadata files

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -277,6 +277,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			$(TEST_LOGS) \
 			$(TEST_LOGS:.log=.trs) \
 			$(TEST_SUITE_LOG) \
+			$(TESTS:=.test) \
 			"*.gcda" \
 			"*.gcno" \
 			$(DISTCLEANFILES) \


### PR DESCRIPTION
The installed-tests standard requires .test files to be generated for
each installed test. We don’t actually know the variable which lists all
the installed tests, but almost all modules use TESTS to list them too.

https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests

This could cause problems if a test is listed in TESTS but a similar one
with a .test extension also exists (e.g. if TEST_EXTENSIONS is being
used). That is a bit of a corner case though.