### PR TITLE
Add short description to top of git.mk file

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -1,4 +1,5 @@
-# git.mk
+# git.mk, a small Makefile to autogenerate .gitignore files
+# for autotools-based projects.
 #
 # Copyright 2009, Red Hat, Inc.
 # Copyright 2010,2011,2012,2013 Behdad Esfahbod


### PR DESCRIPTION
When included in a project, this makes it obvious upon a quick glance
that git.mk is for generating .gitignore files, and not for anything
else to do with Git and Makefiles.