### PR TITLE
Ignore stamp-po files from gettext

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -243,6 +243,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 				po/POTFILES \
 				po/Rules-quot \
 				po/stamp-it \
+				po/stamp-po \
 				po/.intltool-merge-cache \
 				"po/*.gmo" \
 				"po/*.header" \


### PR DESCRIPTION
They are removed as part of maintainer-clean in po/Makefile, but are
part of a custom rule rather than MAINTAINERCLEANFILES.