### PR TITLE
Avoid errors if $(LTCOMPILE) has shell code in it

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -275,7 +275,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 		if test "x$(am__dirstamp)" = x; then :; else \
 			echo "$(am__dirstamp)"; \
 		fi; \
-		if test "x$(LTCOMPILE)" = x -a "x$(LTCXXCOMPILE)" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
+		if test "x$(findstring libtool,$(LTCOMPILE))" = x -a "x$(findstring libtool,$(LTCXXCOMPILE))" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
 			for x in \
 				"*.lo" \
 				".libs" "_libs" \


### PR DESCRIPTION
In https://github.com/ostreedev/ostree we have some shell quoting
in `$(AM_CPPFLAGS)` like `-DOSTREE_FEATURES='"$(OSTREE_FEATURES)"'`.
This ends up in `$(LTCOMPILE)` which causes shell errors since we
are trying to quote outside of it.

Fix this by using `findstring` to pick out the string libtool if it
exists, which is obviously shell-safe.